### PR TITLE
Make image smaller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 template
 build
+
+.secrets

--- a/template/crystal/Dockerfile
+++ b/template/crystal/Dockerfile
@@ -13,19 +13,16 @@ RUN strip handler
 
 FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine as ship
 RUN apk update && apk upgrade
-
+# Add non root user
 # Add non root user
 RUN addgroup -S app && adduser app -S -G app
 
 WORKDIR /home/app
+USER app
 
 COPY --from=build /home/app/function/  .
 COPY --from=build /home/app/handler    .
-COPY --from=watchdog /fwatchdog        .
-RUN chmod +x /home/app/fwatchdog
-RUN chown app /home/app
-
-USER app
+COPY --from=watchdog /fwatchdog /home/app/fwatchdog
 
 ENV fprocess="./handler"
 EXPOSE 8080

--- a/template/crystal/Dockerfile
+++ b/template/crystal/Dockerfile
@@ -1,32 +1,29 @@
-FROM crystallang/crystal:1.8.0 as builder
+FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.9.10 as watchdog
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine as build
 
-RUN apt update \
-    && apt install -y curl \
-    && echo "Pulling watchdog binary from Github." \
-    && curl -sSL https://github.com/openfaas/faas/releases/download/0.9.6/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog
-
+RUN apk update && apk upgrade
+RUN apk add crystal shards
 WORKDIR /home/app
 COPY . .
 
 COPY function/shard.yml shard.yml
 RUN shards install
-RUN crystal build main.cr -o handler --release
+RUN crystal build main.cr -o handler --release --static
+RUN strip handler
 
-FROM crystallang/crystal:1.8.0
-RUN apt install ca-certificates
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine as ship
+RUN apk update && apk upgrade
 
 # Add non root user
-RUN adduser app
-RUN mkdir -p /home/app
+RUN addgroup -S app && adduser app -S -G app
 
 WORKDIR /home/app
 
-COPY --from=builder /usr/bin/fwatchdog   .
-COPY --from=builder /home/app/function/  .
-COPY --from=builder /home/app/handler    .
-
-RUN chown -R app /home/app
+COPY --from=build /home/app/function/  .
+COPY --from=build /home/app/handler    .
+COPY --from=watchdog /fwatchdog        .
+RUN chmod +x /home/app/fwatchdog
+RUN chown app /home/app
 
 USER app
 

--- a/template/crystal/Dockerfile
+++ b/template/crystal/Dockerfile
@@ -3,6 +3,7 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine as build
 
 RUN apk update && apk upgrade
 RUN apk add crystal shards
+RUN apk cache clean
 WORKDIR /home/app
 COPY . .
 
@@ -12,7 +13,7 @@ RUN crystal build main.cr -o handler --release --static
 RUN strip handler
 
 FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine as ship
-RUN apk update && apk upgrade
+RUN apk update && apk upgrade && apk cache clean
 # Add non root user
 # Add non root user
 RUN addgroup -S app && adduser app -S -G app


### PR DESCRIPTION
This PR makes some changes to the Dockerfile:

* Bases it off alpine instead of ubuntu
* Uses a separate ship image so we don't ship crystal itself
* Use the TARGETPLATFORM variable from faas so it works for ARM as well
* Build as static (which according to the docs works well in alpine)
* Strip the binary to save a few bytes because why not :-)
* Keep binaries owned by root, which should not be a problem

In general, this brings the image (compressed) from some 300MB to around 12MB without any functional changes.

Hope you like the changes!